### PR TITLE
Correct misinterpretation of exceptions on D3D initialization

### DIFF
--- a/CFHodEd/ApplicationEvents.vb
+++ b/CFHodEd/ApplicationEvents.vb
@@ -91,11 +91,13 @@ Namespace My
             Try
                 InitializeD3DHelper()
 
-            Catch ex As IO.FileNotFoundException
-                MsgBox("Please install the latest version of DirectX (August 2007 or later).",
+            Catch ex As Exception
+                If TypeOf ex Is IO.FileNotFoundException Then
+                    MsgBox("Please install the latest version of DirectX (August 2007 or later).",
                        MsgBoxStyle.Critical, "Cold Fusion HOD Editor")
 
-                End
+                    End
+                End If
 
             End Try
 


### PR DESCRIPTION
Typing a catch expression does not filter out other exceptions in VB like it does in C#, so this was causing any exception (in my case a LoaderLock exception) to be interpreted as a D3D failure.